### PR TITLE
Ensure unique datapoint ids

### DIFF
--- a/ampel/lsst/ingest/LSSTDataPointShaper.py
+++ b/ampel/lsst/ingest/LSSTDataPointShaper.py
@@ -49,10 +49,13 @@ class LSSTDataPointShaper(AbsT0Unit):
             Non detection limit don't have an identifier.
             """
 
+            id = hash_payload(
+                encode(dict(sorted(photo_dict.items()))),
+                size=-self.digest_size * 8,
+            )
             if "diaSourceId" in photo_dict:
-                id = photo_dict["diaSourceId"]
                 tags.append("LSST_DP")
-                sourceid_list.add(id)
+                sourceid_list.add(photo_dict["diaSourceId"])
             elif "diaForcedSourceId" in photo_dict:
                 id = photo_dict["diaForcedSourceId"]
                 tags.append("LSST_FP")
@@ -63,10 +66,6 @@ class LSSTDataPointShaper(AbsT0Unit):
                 tags.append("LSST_OBJ")
             else:
                 # Nondetection Limit
-                id = hash_payload(
-                    encode(dict(sorted(photo_dict.items()))),
-                    size=-self.digest_size * 8,
-                )
                 tags.append("LSST_ND")
                 print("OOOOOO do we have upper limits?")
             ret_list.append(
@@ -79,5 +78,5 @@ class LSSTDataPointShaper(AbsT0Unit):
         return [
             dp
             for dp in ret_list
-            if not (dp["id"] in sourceid_list and "LSST_FP" in dp["tag"])
+            if not (dp["body"].get("diaSourceId") in sourceid_list and "LSST_FP" in dp["tag"])
         ]

--- a/ampel/lsst/ingest/LSSTDataPointShaper.py
+++ b/ampel/lsst/ingest/LSSTDataPointShaper.py
@@ -57,12 +57,10 @@ class LSSTDataPointShaper(AbsT0Unit):
                 tags.append("LSST_DP")
                 sourceid_list.add(photo_dict["diaSourceId"])
             elif "diaForcedSourceId" in photo_dict:
-                id = photo_dict["diaForcedSourceId"]
                 tags.append("LSST_FP")
             elif "diaObjectId" in photo_dict:  # DiaObject
                 # diaObjectId is also used in (prv)diaSource and diaForcedPhotometry
                 # if other fields are added, check if they contain diaObjectId
-                id = photo_dict["diaObjectId"]
                 tags.append("LSST_OBJ")
             else:
                 # Nondetection Limit
@@ -78,5 +76,5 @@ class LSSTDataPointShaper(AbsT0Unit):
         return [
             dp
             for dp in ret_list
-            if not (dp["body"].get("diaSourceId") in sourceid_list and "LSST_FP" in dp["tag"])
+            if not (dp["body"].get("diaForcedSourceId") in sourceid_list and "LSST_FP" in dp["tag"])
         ]


### PR DESCRIPTION
Quoth @wombaugh:

> I have encountered an issue of my own when parsing the distributed elasticc2 alerts: Among these, the dieSourceID which we use to identifiy datapoints can in very rare cases be duplicates of the diaObjectId which is used to identify transients. This affects us since we use the diaObjectId as id when storing a special dp with e.g. redshift information.

Avoid (almost all) id collisions by using the hash of the body as the datapoint id. This is analogous to AmpelProject/Ampel-ZTF#60, and has the same weaknesses. Since we don't use any information encoded in diaObjectId/diaSourceId (if it exists), this should be a minimal change. 