### PR TITLE
Explicitly acknowledge Kafka messages

### DIFF
--- a/ampel/lsst/alert/load/HttpSchemaRepository.py
+++ b/ampel/lsst/alert/load/HttpSchemaRepository.py
@@ -2,7 +2,7 @@ from pathlib import PurePosixPath
 from urllib.parse import urlsplit, urlunsplit
 
 import requests
-from fastavro.schema import load_schema
+import fastavro.schema
 from fastavro.types import Schema
 from fastavro.repository.base import (
     AbstractSchemaRepository,
@@ -33,7 +33,7 @@ class HttpSchemaRepostory(AbstractSchemaRepository):
     @classmethod
     def load_schema(cls, url: str) -> Schema:
         base, schema, ext = cls.get_parts(url)
-        return load_schema(schema, repo=cls(base, ext))
+        return fastavro.schema.load_schema(schema, repo=cls(base, ext))
 
     def __init__(self, base_url: str, file_ext: str = ".avsc"):
         self.base_url = base_url
@@ -56,4 +56,4 @@ def parse_schema(schema_or_url: str | dict) -> Schema:
     if isinstance(schema_or_url, str):
         return HttpSchemaRepostory.load_schema(schema_or_url)
     else:
-        return load_schema(schema_or_url)
+        return fastavro.schema.parse_schema(schema_or_url)

--- a/poetry.lock
+++ b/poetry.lock
@@ -126,37 +126,37 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "ampel-alerts"
-version = "0.8.5"
+version = "0.8.6a0"
 description = "Alert support for the Ampel system"
 category = "main"
 optional = false
 python-versions = ">=3.10,<3.12"
 files = [
-    {file = "ampel_alerts-0.8.5-py3-none-any.whl", hash = "sha256:8992a1b7719cf1ddd5739367ca2b0ee18661451c0ed2fe3b32bc917952985d35"},
-    {file = "ampel_alerts-0.8.5.tar.gz", hash = "sha256:991a2c82b138de76f0f760dfb5749c784eb444f0494f4d99473834eac137e36f"},
+    {file = "ampel_alerts-0.8.6a0-py3-none-any.whl", hash = "sha256:10bf92ae76c468c1d1417d2c5dc65a06eb0012f4fd06313310300b02a4f97c03"},
+    {file = "ampel_alerts-0.8.6a0.tar.gz", hash = "sha256:f17c07eb473423ac676f9171bb7d97d6b010bbd116fd773149e4a8acd6fe6db7"},
 ]
 
 [package.dependencies]
-ampel-core = ">=0.8.6,<0.9.0"
-ampel-interface = ">=0.8.7,<0.9.0"
+ampel-core = ">=0.8.7a0,<0.9"
+ampel-interface = ">=0.8.7,<0.9"
 
 [package.extras]
 docs = ["Sphinx (>=6.1.2,<6.2.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "tomlkit (>=0.11.0,<0.12.0)"]
 
 [[package]]
 name = "ampel-core"
-version = "0.8.6"
+version = "0.8.7a0"
 description = "Alice in Modular Provenance-Enabled Land"
 category = "main"
 optional = false
 python-versions = ">=3.10,<3.12"
 files = [
-    {file = "ampel_core-0.8.6-py3-none-any.whl", hash = "sha256:c3132fbe9b585a33c4e747d4d79e4ba454368ecb38e917ddc6b9c01c196c89d4"},
-    {file = "ampel_core-0.8.6.tar.gz", hash = "sha256:d0fca9bc7ef33223f962da275b7008aad89355e3d20d5294b97ab8cb02e38126"},
+    {file = "ampel_core-0.8.7a0-py3-none-any.whl", hash = "sha256:162d1b7e4c22eb7aa317742bd5e7ec15033c58f1e9ababc06eed24da6df1c947"},
+    {file = "ampel_core-0.8.7a0.tar.gz", hash = "sha256:07815524982202331abf828e60c4ae89c0128f6b721ee6553afe358af7deb08c"},
 ]
 
 [package.dependencies]
-ampel-interface = ">=0.8.7,<0.9.0"
+ampel-interface = ">=0.8.10,<0.9.0"
 appdirs = ">=1.4.4,<2.0.0"
 prometheus-client = ">=0.16,<0.17"
 psutil = ">=5.8.0,<6.0.0"
@@ -216,14 +216,14 @@ docs = ["Sphinx (>=6.1.3,<6.2.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)",
 
 [[package]]
 name = "ampel-ztf"
-version = "0.8.7"
+version = "0.8.8"
 description = "Zwicky Transient Facility support for the Ampel system"
 category = "main"
 optional = false
 python-versions = ">=3.10,<3.12"
 files = [
-    {file = "ampel_ztf-0.8.7-py3-none-any.whl", hash = "sha256:ef8633350abdc7d1c0fcdf7e5f781c885148496dffadfa05c6a2b8fc0d45d0e2"},
-    {file = "ampel_ztf-0.8.7.tar.gz", hash = "sha256:eb0790ad81f713e74f790e91bcc719fd7700eb01205663a29ac335e8cdd3188c"},
+    {file = "ampel_ztf-0.8.8-py3-none-any.whl", hash = "sha256:f7bce56879411d1a80f30400085cac51269c22b78c192bafcd2f0d6b61ca7113"},
+    {file = "ampel_ztf-0.8.8.tar.gz", hash = "sha256:83fc206dd1a7dec417365f0711c01a00c2ab26095d9091bf8e68a128dae83faa"},
 ]
 
 [package.dependencies]
@@ -1796,6 +1796,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1803,8 +1804,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1821,6 +1829,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1828,6 +1837,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2327,4 +2337,4 @@ tests = ["build", "coverage", "mypy", "ruff", "wheel"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "e9e56c7c13d3d564a3efadcb63ade1630027d45293140ffaeeaed29eee7749c8"
+content-hash = "95db07423850c890ff071e06ea129ad78ed55fe029408323c66cb5ec86f36b31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-lsst"
-version = "0.8.6"
+version = "0.8.7a0"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 authors = [
     "Marcus Fenner <mf@physik.hu-berlinn.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ include = [
 python = ">=3.10,<3.12"
 astropy = "^5.0.2"
 fastavro = "^1.3.2"
-ampel-ztf = {version = "^0.8.5", extras = ["kafka"]}
-ampel-alerts = {version = "^0.8.5"}
+ampel-ztf = {version = ">=0.8.8,<0.9", extras = ["kafka"]}
+ampel-alerts = {version = ">=0.8.6a0,<0.9"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+import pytest
+
+from pathlib import Path
+
+import pytest
+import mongomock
+
+from itertools import cycle
+
+from ampel.dev.DevAmpelContext import DevAmpelContext
+from ampel.abstract.AbsAlertLoader import AbsAlertLoader
+from ampel.abstract.AbsAlertFilter import AbsAlertFilter, AmpelAlertProtocol
+
+
+class MockAlertLoader(AbsAlertLoader):
+    alerts: list[dict]
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._it = iter(self.alerts)
+
+    def _add_metadata(self, alert: dict) -> dict:
+        alert["__kafka"] = {"alertId": alert["alertId"]}
+        return alert
+
+    def __next__(self):
+        return self._add_metadata(next(self._it))
+
+
+class MockFilter(AbsAlertFilter):
+
+    pattern: list[bool]
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._cycle = cycle(self.pattern)
+
+    def process(self, alert: AmpelAlertProtocol) -> None | bool | int:
+        return next(self._cycle)
+
+
+@pytest.fixture
+def patch_mongo(monkeypatch):
+    monkeypatch.setattr(
+        "ampel.core.AmpelDB.MongoClient", mongomock.MongoClient
+    )
+    # ignore codec_options in DataLoader
+    monkeypatch.setattr(
+        "mongomock.codec_options.is_supported", lambda *args: None
+    )
+
+
+@pytest.fixture(scope="session")
+def testing_config():
+    return Path(__file__).parent / "test-data" / "testing-config.yaml"
+
+
+@pytest.fixture
+def mock_context(patch_mongo, testing_config: Path):
+    ctx: DevAmpelContext = DevAmpelContext.load(
+        config=str(testing_config), purge_db=True
+    )
+    for c in "ElasticcLong", "ElasticcShort":
+        ctx.add_channel(c)
+    ctx.register_unit(MockAlertLoader)
+    ctx.register_unit(MockFilter)
+    return ctx

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,79 +1,18 @@
+import pytest
+import yaml
+import fastavro
+
 from pathlib import Path
 from ampel.base.AuxUnitRegister import AuxUnitRegister
 from ampel.lsst.alert.LSSTAlertSupplier import LSSTAlertSupplier
 
-import yaml
-import pytest
-import mongomock
-import fastavro
-
-from itertools import cycle
-
 from ampel.dev.DevAmpelContext import DevAmpelContext
-from ampel.model.UnitModel import UnitModel
 from ampel.alert.AlertConsumer import AlertConsumer
-from ampel.abstract.AbsAlertLoader import AbsAlertLoader
-from ampel.abstract.AbsAlertFilter import AbsAlertFilter, AmpelAlertProtocol
-
-
-class MockAlertLoader(AbsAlertLoader):
-    alerts: list[dict]
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._it = iter(self.alerts)
-
-    def __next__(self):
-        return next(self._it)
-
-
-class MockFilter(AbsAlertFilter):
-
-    pattern: list[bool]
-
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self._cycle = cycle(self.pattern)
-
-    def process(self, alert: AmpelAlertProtocol) -> None | bool | int:
-        return next(self._cycle)
+from ampel.model.UnitModel import UnitModel
 
 
 @pytest.fixture
-def patch_mongo(monkeypatch):
-    monkeypatch.setattr(
-        "ampel.core.AmpelDB.MongoClient", mongomock.MongoClient
-    )
-    # ignore codec_options in DataLoader
-    monkeypatch.setattr(
-        "mongomock.codec_options.is_supported", lambda *args: None
-    )
-
-
-@pytest.fixture(scope="session")
-def testing_config():
-    return Path(__file__).parent / "test-data" / "testing-config.yaml"
-
-
-@pytest.fixture
-def mock_context(patch_mongo, testing_config: Path):
-    ctx: DevAmpelContext = DevAmpelContext.load(
-        config=str(testing_config), purge_db=True
-    )
-    for c in "ElasticcLong", "ElasticcShort":
-        ctx.add_channel(c)
-    ctx.register_unit(MockAlertLoader)
-    ctx.register_unit(MockFilter)
-    return ctx
-
-
-def test_muxer(mock_context: DevAmpelContext):
-    """
-    A point T2 bound to a specific datapoint appears for both channels, even
-    when the alert where the target datapoint first appeared was accepted by
-    only one channel.
-    """
-
+def alert_consumer(mock_context: DevAmpelContext) -> AlertConsumer:
     with (
         Path(__file__).parent / "test-data" / "elasticc-consumer.yml"
     ).open() as f:
@@ -99,12 +38,25 @@ def test_muxer(mock_context: DevAmpelContext):
         context=mock_context,
         sub_type=AlertConsumer,
     )
-    processor.iter_max = 1
+
+    return processor
+
+
+def test_muxer(
+    mock_context: DevAmpelContext, alert_consumer: AlertConsumer, mocker
+):
+    """
+    A point T2 bound to a specific datapoint appears for both channels, even
+    when the alert where the target datapoint first appeared was accepted by
+    only one channel.
+    """
+
+    alert_consumer.iter_max = 1
 
     # insert datapoints from first alert into the database
-    assert processor.run() == 1
+    assert alert_consumer.run() == 1
     # inserts datapoints unique to second alert
-    assert processor.run() == 1
+    assert alert_consumer.run() == 1
 
     assert (
         len(mock_context.db.get_collection("stock").find_one()["channel"]) == 2
@@ -120,6 +72,25 @@ def test_muxer(mock_context: DevAmpelContext):
         == 1
     ), "single point T2 doc found"
     assert len(set(docs[0]["channel"])) == 2, "t2 doc in both channels"
+
+
+def test_message_ack(alert_consumer: AlertConsumer, mocker):
+    """
+    Alerts are explicitly acknowledged back to the loader
+    """
+    ack = mocker.patch.object(
+        alert_consumer.alert_supplier.alert_loader, "acknowledge"
+    )
+
+    assert alert_consumer.run() == 2
+
+    assert ack.call_count == 1, "exactly one batch of acks"
+    alerts = list(ack.call_args[0][0])
+    assert len(alerts) == 2
+    assert alerts == [
+        {"__kafka": {"alertId": alert["alertId"]}}
+        for alert in alert_consumer.alert_supplier.alert_loader.alerts
+    ], "alerts acked"
 
 
 def test_duplicate_datapoints(mock_context: DevAmpelContext):

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -85,7 +85,8 @@ def test_message_ack(alert_consumer: AlertConsumer, mocker):
     assert alert_consumer.run() == 2
 
     assert ack.call_count == 1, "exactly one batch of acks"
-    alerts = list(ack.call_args[0][0])
+    # NB: alerts may be acked in arbitrary order
+    alerts = sorted(ack.call_args[0][0], key=lambda d: d["__kafka"]["alertId"])
     assert len(alerts) == 2
     assert alerts == [
         {"__kafka": {"alertId": alert["alertId"]}}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,114 @@
+import datetime
+import io
+from pathlib import Path
+
+import confluent_kafka
+import fastavro
+import pytest
+from pytest_mock import MockerFixture
+
+from ampel.lsst.alert.LSSTAlertSupplier import LSSTAlertSupplier
+from ampel.model.UnitModel import UnitModel
+
+
+class MockMessage:
+    """
+    Mockup of confluent_kafka.Message, which can't be instantiated from Python
+    """
+    def __init__(self, record: dict, schema: dict, offset: int):
+        buf = io.BytesIO()
+        fastavro.schemaless_writer(buf, schema, record)
+        self._value = buf.getvalue()
+        self._offset = offset
+        self._timestamp = confluent_kafka.TIMESTAMP_CREATE_TIME, int(
+            datetime.datetime.now().timestamp() * 1000
+        )
+
+    def value(self):
+        return self._value
+
+    def error(self):
+        return None
+
+    def key(self):
+        return None
+
+    def topic(self):
+        return "topic"
+
+    def partition(self):
+        return 0
+
+    def offset(self):
+        return self._offset
+
+    def timestamp(self):
+        return self._timestamp
+
+
+@pytest.fixture
+def test_alerts():
+    """Turn alerts back into Kafka messages"""
+    with (Path(__file__).parent / "test-data" / "11290844.avro").open(
+        "rb"
+    ) as f:
+        reader = fastavro.reader(f)
+        return reader.writer_schema, [
+            MockMessage(record, reader.writer_schema, offset)
+            for offset, record in enumerate(reader)
+        ]
+
+
+def test_loader_ack(
+    mocker: MockerFixture,
+    mock_context,
+    test_alerts: tuple[dict, list[MockMessage]],
+):
+    """
+    LSSTAlertLoader acknowledges alerts back to AllConsumingConsumer
+    """
+    schema, messages = test_alerts
+
+    supplier = LSSTAlertSupplier(
+        deserialize=None,
+        loader=UnitModel(
+            unit="KafkaAlertLoader",
+            config={
+                "bootstrap": "foo",
+                "topics": ["topic"],
+                "avro_schema": schema,
+            },
+        ),
+    )
+
+    mock_consumer = mocker.patch.object(
+        supplier.alert_loader._consumer, "_consumer"
+    )
+    mock_consumer.poll.side_effect = messages
+
+    assert supplier.alert_loader._consumer._consumer is mock_consumer
+
+    alerts = list(supplier)
+    assert len(alerts) == 3
+
+    assert supplier.alert_loader._consumer._offsets == {("topic", 0): 2}
+    assert not mock_consumer.store_offsets.called
+    assert not mock_consumer.commit.called
+
+    def verify_offset(offset):
+        offsets = mock_consumer.commit.call_args[1]["offsets"]
+        assert len(offsets) == 1
+        toppar = offsets[0]
+        assert toppar.topic == "topic"
+        assert toppar.partition == 0
+        assert toppar.offset == offset
+
+    supplier.acknowledge(iter(alerts[:2]))
+    assert not mock_consumer.store_offsets.called
+    assert mock_consumer.commit.called
+    # offset is at the second alert, even though all have been consumed
+    verify_offset(1)
+
+    supplier.acknowledge(reversed(alerts))
+    # offset is at the last alert, even though acks came out of order
+    verify_offset(2)


### PR DESCRIPTION
By default, KafkaAlertLoader stores the offset of the previously emitted message when the next one is requested. This causes the current message to be redelivered if the client terminates before handling it (and thus never requests a next message), but does not handle failures when messages are processed in batches, e.g. if AlertConsumer is terminated unexpectedly before DBUpdatesBuffer can push an update. This PR adds the capability for LSSTAlertSupplier to receive explicit alert acknowledgments (from DBUpdatesBuffer) and pass these on to the confluent_kafka.Consumer held by KafkaAlertLoader.