### PR TITLE
Support Rubin USDF Kafka broker

### DIFF
--- a/ampel/lsst/alert/load/KafkaAlertLoader.py
+++ b/ampel/lsst/alert/load/KafkaAlertLoader.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import io
 import itertools
 import logging
 import uuid
@@ -8,14 +7,14 @@ from collections.abc import Iterable, Iterator
 from typing import Any
 
 import confluent_kafka
-import fastavro
+from confluent_kafka.deserializing_consumer import DeserializingConsumer
 from pydantic import Field
 
 from ampel.abstract.AbsAlertLoader import AbsAlertLoader
 from ampel.log.AmpelLogger import AmpelLogger
-from ampel.ztf.t0.load.AllConsumingConsumer import AllConsumingConsumer
 
-from .HttpSchemaRepository import DEFAULT_SCHEMA, parse_schema
+from .HttpSchemaRepository import DEFAULT_SCHEMA
+from .PlainAvroDeserializer import PlainAvroDeserializer
 
 log = logging.getLogger(__name__)
 
@@ -42,22 +41,26 @@ class KafkaAlertLoader(AbsAlertLoader[dict]):
         super().__init__(**kwargs)
 
         config = {
+            "bootstrap.servers": self.bootstrap,
             "group.id": self.group_name,
-            "auto_commit": False,
+            "auto.offset.reset": "smallest",
+            "enable.auto.commit": True,
+            "enable.auto.offset.store": False,
+            "auto.commit.interval.ms": 10000,
+            "receive.message.max.bytes": 2**29,
+            "enable.partition.eof": False,  # don't emit messages on EOF
+            "value.deserializer": PlainAvroDeserializer(self.avro_schema),
         } | self.kafka_consumer_properties
 
-        self._consumer = AllConsumingConsumer(
-            self.bootstrap,
-            timeout=self.timeout,
-            topics=self.topics,
-            logger=self.logger,
-            **config,
-        )
+        self._consumer = DeserializingConsumer(config)
+        self._consumer.subscribe(self.topics)
         self._it = None
+
+        self._poll_interval = max((1, min((3, self.timeout))))
+        self._poll_attempts = max((1, int(self.timeout / self._poll_interval)))
 
     def set_logger(self, logger: AmpelLogger) -> None:
         super().set_logger(logger)
-        self._consumer._logger = logger  # noqa: SLF001
 
     @staticmethod
     def _add_message_metadata(alert: dict, message: confluent_kafka.Message):
@@ -81,43 +84,80 @@ class KafkaAlertLoader(AbsAlertLoader[dict]):
         return alert
 
     def acknowledge(self, alert_dicts: Iterable[dict]) -> None:
+        """
+        Store offsets of fully-processed messages
+        """
         offsets: dict[tuple[str, int], int] = dict()
         for alert in alert_dicts:
             meta = alert["__kafka"]
             key, value = (meta["topic"], meta["partition"]), meta["offset"]
             if key not in offsets or value > offsets[key]:
                 offsets[key] = value
-        self._consumer.store_offsets(
-            [
-                confluent_kafka.TopicPartition(topic, partition, offset + 1)
-                for (topic, partition), offset in offsets.items()
-            ]
-        )
+        try:
+            self._consumer.store_offsets(
+                offsets=[
+                    confluent_kafka.TopicPartition(
+                        topic, partition, offset + 1
+                    )
+                    for (topic, partition), offset in offsets.items()
+                ]
+            )
+        except confluent_kafka.KafkaException as exc:
+            # librdkafka will refuse to store offsets on a partition that is not
+            # currently assigned. this can happen if the group is rebalanced
+            # while a batch of messages is in flight. see also:
+            # https://github.com/confluentinc/confluent-kafka-dotnet/issues/1861
+            err = exc.args[0]
+            if err.code() != confluent_kafka.KafkaError._STATE:  # noqa: SLF001
+                raise
+
+    def _poll(self) -> confluent_kafka.Message | None:
+        """
+        Poll for a message, ignoring nonfatal errors
+        """
+        message = None
+        for _ in range(self._poll_attempts):
+            # wake up occasionally to catch SIGINT
+            message = self._consumer.poll(self._poll_interval)
+            if message is not None:
+                if err := message.error():
+                    if (
+                        err.code()
+                        == confluent_kafka.KafkaError.UNKNOWN_TOPIC_OR_PART
+                    ):
+                        # ignore unknown topic messages
+                        continue
+                    if err.code() in (
+                        confluent_kafka.KafkaError._TIMED_OUT,  # noqa: SLF001
+                        confluent_kafka.KafkaError._MAX_POLL_EXCEEDED,  # noqa: SLF001
+                    ):
+                        # bail on timeouts
+                        if self._logger:
+                            self._logger.debug(f"Got {err}")
+                        return None
+                break
+        if message is None:
+            return message
+        if message.error():
+            raise message.error()
+        return message
+
+    def _consume(self) -> Iterator[dict]:
+        while True:
+            message = self._poll()
+            if message is None:
+                return
+            else:
+                yield self._add_message_metadata(message.value(), message)
 
     def alerts(self, limit: None | int = None) -> Iterator[dict]:
         """
         Generate alerts until timeout is reached
         :returns: dict instance of the alert content
-        :raises StopIteration: when next(fastavro.reader) has dried out
+        :raises StopIteration: when no alerts recieved within timeout
         """
 
-        schema = parse_schema(self.avro_schema)
-
-        for message in itertools.islice(self._consumer, limit):
-            alert = fastavro.schemaless_reader(
-                io.BytesIO(message.value()),
-                writer_schema=schema,
-                reader_schema=None,
-            )
-            if isinstance(alert, list):
-                for d in alert:
-                    yield self._add_message_metadata(d, message)
-            elif isinstance(alert, dict):
-                yield self._add_message_metadata(alert, message)
-            else:
-                raise TypeError(
-                    f"can't handle messages that deserialize to {type(message)}"
-                )
+        yield from itertools.islice(self._consume(), limit)
 
     def __next__(self) -> dict:
         if self._it is None:

--- a/ampel/lsst/alert/load/KafkaAlertLoader.py
+++ b/ampel/lsst/alert/load/KafkaAlertLoader.py
@@ -43,7 +43,7 @@ class KafkaAlertLoader(AbsAlertLoader[dict]):
     """
 
     #: Address of Kafka broker
-    bootstrap: str = "public.alerts.ztf.uw.edu:9092"
+    bootstrap: str
     #: Optional authentication
     auth: None | SASLAuthentication = None
     #: Topics to subscribe to

--- a/ampel/lsst/alert/load/PlainAvroDeserializer.py
+++ b/ampel/lsst/alert/load/PlainAvroDeserializer.py
@@ -1,0 +1,22 @@
+import io
+
+import fastavro
+from confluent_kafka.serialization import Deserializer, SerializationContext
+
+from .HttpSchemaRepository import parse_schema
+
+
+class PlainAvroDeserializer(Deserializer):
+    """
+    Deserializer for static schemas
+    """
+
+    def __init__(self, avro_schema: dict | str):
+        self._schema = parse_schema(avro_schema)
+
+    def __call__(self, value: bytes, ctx: SerializationContext) -> dict:  # noqa: ARG002
+        return fastavro.schemaless_reader(  # type: ignore[return-value]
+            io.BytesIO(value),
+            writer_schema=self._schema,
+            reader_schema=None,
+        )


### PR DESCRIPTION
Updates to KafkaConsumer to support what we will actually use for LSST:
- Decouple from ampel-ztf
- Remove support for auto-committing offsets (IngestionHandler now explicitly acks alerts that have been processed)
- Support SASL authentication
- Support Confluent Wire Format messages (schema registry)