### PR TITLE
Improve cooperation in KafkaConsumer/Producer

### DIFF
--- a/ampel/lsst/alert/load/KafkaAlertLoader.py
+++ b/ampel/lsst/alert/load/KafkaAlertLoader.py
@@ -2,6 +2,7 @@
 
 import itertools
 from collections.abc import Callable, Iterable, Iterator
+from threading import Event
 from typing import Any
 
 import confluent_kafka
@@ -91,8 +92,9 @@ class KafkaAlertLoader(KafkaConsumerBase, AbsAlertLoader[dict]):
                 raise
 
     def _consume(self) -> Iterator[dict]:
-        while True:
-            message = self._poll()
+        stop = Event()
+        while not stop.is_set():
+            message = self._poll(stop)
             if message is None:
                 return
             else:

--- a/ampel/lsst/alert/load/KafkaAlertLoader.py
+++ b/ampel/lsst/alert/load/KafkaAlertLoader.py
@@ -17,7 +17,7 @@ _get_schema: Callable[[Any], AvroSchema] = TypeAdapter(
 ).validate_python
 
 
-class KafkaAlertLoader(AbsAlertLoader[dict], KafkaConsumerBase):
+class KafkaAlertLoader(KafkaConsumerBase, AbsAlertLoader[dict]):
     """
     Load alerts from one or more Kafka topics
     """

--- a/ampel/lsst/kafka/KafkaConsumer.py
+++ b/ampel/lsst/kafka/KafkaConsumer.py
@@ -11,7 +11,7 @@ from .KafkaConsumerBase import KafkaConsumerBase
 
 class KafkaConsumer(KafkaConsumerBase, AbsConsumer[QueueItem]):
     def consume(self) -> None | QueueItem:
-        message = self._poll()
+        message = self._poll(self.stop)
         if message is None:
             return None
         item: QueueItem = bson.decode(message.value())  # type: ignore[assignment]

--- a/ampel/lsst/kafka/KafkaProducerBase.py
+++ b/ampel/lsst/kafka/KafkaProducerBase.py
@@ -4,7 +4,7 @@ from typing import Any, Generic, TypeVar
 
 from confluent_kafka import KafkaException, Producer
 
-from ampel.base.AmpelABC import AmpelABC
+from ampel.abstract.AbsContextManager import AbsContextManager
 from ampel.base.decorator import abstractmethod
 
 from .SASLAuthentication import SASLAuthentication
@@ -12,7 +12,7 @@ from .SASLAuthentication import SASLAuthentication
 _T = TypeVar("_T")
 
 
-class KafkaProducerBase(AmpelABC, Generic[_T], abstract=True):
+class KafkaProducerBase(AbsContextManager, Generic[_T], abstract=True):
     bootstrap: str
     topic: str
     auth: None | SASLAuthentication = None
@@ -54,7 +54,7 @@ class KafkaProducerBase(AmpelABC, Generic[_T], abstract=True):
         )
         self._producer.poll(0)
 
-    def flush(self):
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         if (in_queue := self._producer.flush(self.delivery_timeout)) > 0:
             raise TimeoutError(
                 f"{in_queue} messages still in queue after {self.delivery_timeout} s"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,29 +2,29 @@
 
 [[package]]
 name = "ampel-alerts"
-version = "0.10.3a1"
+version = "0.10.3a4"
 description = "Alert support for the Ampel system"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "ampel_alerts-0.10.3a1-py3-none-any.whl", hash = "sha256:84b478feae35cd13032c2b8903cdfb57ae3dadaf6b177049918fe070603a63c6"},
-    {file = "ampel_alerts-0.10.3a1.tar.gz", hash = "sha256:dde971e6d81450ad99814355a110ace60c2b80d4218ff710aecdc10e312b5510"},
+    {file = "ampel_alerts-0.10.3a4-py3-none-any.whl", hash = "sha256:a25cd5849f6a3a634e6aec8fa33027a5df8fafbb3ad77730f451102dde657768"},
+    {file = "ampel_alerts-0.10.3a4.tar.gz", hash = "sha256:1b52ea8e49a57a6fb96c144922a6e6e4d81025dd7a21d2eb3339b9a4fa0b082e"},
 ]
 
 [package.dependencies]
-ampel-core = ">=0.10.6a0,<0.11"
+ampel-core = ">=0.10.6a7,<0.11"
 
 [[package]]
 name = "ampel-core"
-version = "0.10.6a1"
+version = "0.10.6a7"
 description = "Alice in Modular Provenance-Enabled Land"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "ampel_core-0.10.6a1-py3-none-any.whl", hash = "sha256:5ad8e2a0c4ab642cefb5fb9373c2931cda68770587dc6fc7cad9a29bd539a2de"},
-    {file = "ampel_core-0.10.6a1.tar.gz", hash = "sha256:d485d511802769f7699e26102727e77bff7f32f92fcd4ecc09292f3dedf6a7d4"},
+    {file = "ampel_core-0.10.6a7-py3-none-any.whl", hash = "sha256:4fe8e112f21b7513ba0d3e19b6a7877627f9e0f357588f78078eaa373ea418be"},
+    {file = "ampel_core-0.10.6a7.tar.gz", hash = "sha256:0181774bb6fd0eadd6ee571321dab239a736a917df3f3a133ccc88df22f938be"},
 ]
 
 [package.dependencies]
@@ -2353,4 +2353,4 @@ kafka = ["confluent-kafka"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7b34a1c165a173fe71dd8480e518ff395dba94c112924f92e08916c4deaec26d"
+content-hash = "8ff467310ac15ab565d0b879a240156c4d1c62ea65847b29c4fdc85c7977719b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-lsst"
-version = "0.10.1a0"
+version = "0.10.1a1"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 authors = [
     "Marcus Fenner <mf@physik.hu-berlinn.de>",
@@ -46,8 +46,8 @@ astropy = ">=5"
 confluent-kafka = {version = "^2.6.1", optional = true, extras = ["schemaregistry"]}
 fastavro = "^1.3.2"
 ampel-ztf = {version = ">=0.10.3a0,<0.11"}
-ampel-core = {version = ">=0.10.6a1,<0.11"}
-ampel-alerts = {version = ">=0.10.3a1,<0.11"}
+ampel-core = {version = ">=0.10.6a7,<0.11"}
+ampel-alerts = {version = ">=0.10.3a4,<0.11"}
 
 [tool.poetry.extras]
 kafka = ["confluent-kafka"]


### PR DESCRIPTION
## Consumer:
- Set a persistent instance ID from HOSTNAME (or other, configurable env var) if available. This allows consumers to [restart without triggering a group rebalance](https://www.confluent.io/en-gb/blog/dynamic-vs-static-kafka-consumer-rebalancing/), potentially causing messages to be redelivered to other consumers in the group.
- Subscribe and commit/unsubscribe in a context manager. This ensures that offsets are committed deterministically, rather than whenever Python decides to free the consumer.
- Explicitly check the stop token when polling for messages. This is cleaner than relying on the default SIGINT handler to throw a KeyboardInterrupt _anywhere_ in the scope.
## Producer:
- Flush enqueued messages at context exit. Again, determinism is good.
- Trigger delivery callbacks from a thread, rather than after every call to produce(). This works around a condition where the input consumer is stuck waiting for new alerts before all output messages had been delivered. This caused offset commit to be delayed until the next call to flush, leaving the last few input messages apparently unconsumed on the broker.