### PR TITLE
Slim LSST alert data

### DIFF
--- a/ampel/lsst/ingest/FieldSelection.py
+++ b/ampel/lsst/ingest/FieldSelection.py
@@ -1,0 +1,70 @@
+from collections.abc import Generator, Iterable
+
+from ampel.base.AmpelBaseModel import AmpelBaseModel
+
+
+class StringFilter(AmpelBaseModel):
+    include: None | set[str] = None
+    exclude: None | set[str] = None
+
+    def filter(self, fields: Iterable[str]) -> Generator[str, None, None]:
+        for field in fields:
+            if self.include is not None and field not in self.include:
+                continue
+            if self.exclude is not None and field in self.exclude:
+                continue
+            yield field
+
+
+class FieldSelection(AmpelBaseModel):
+    """
+    Field selection for LSST data points
+    """
+
+    diaSource: None | StringFilter = None
+    diaForcedSource: None | StringFilter = None
+    diaObject: None | StringFilter = None
+    diaNondetectionLimit: None | StringFilter = None
+
+    @classmethod
+    def default(cls) -> "FieldSelection":
+        return FieldSelection(
+            diaSource=StringFilter(
+                include={
+                    "band",
+                    "dec",
+                    "is_negative",
+                    "midpointMjdTai",
+                    "psfFlux",
+                    "psfFluxErr",
+                    "ra",
+                    "snr",
+                    "visit",
+                },
+                exclude=None,
+            ),
+            diaForcedSource=StringFilter(
+                include={
+                    "band",
+                    "dec",
+                    "midpointMjdTai",
+                    "psfFlux",
+                    "psfFluxErr",
+                    "ra",
+                    "visit",
+                },
+                exclude=None,
+            ),
+            diaObject=StringFilter(
+                include={
+                    "dec",
+                    "decErr",
+                    "ra_dec_Cov",
+                    "ra",
+                    "radecMjdTai",
+                    "raErr",
+                },
+                exclude=None,
+            ),
+            diaNondetectionLimit=None,
+        )

--- a/ampel/lsst/view/LSSTT2Tabulator.py
+++ b/ampel/lsst/view/LSSTT2Tabulator.py
@@ -104,11 +104,9 @@ class LSSTT2Tabulator(AbsT2Tabulator):
         return [str(stock) for stock in self.get_stock_id(dps)]
 
     @staticmethod
-    def get_values(
-        dps: Iterable[DataPoint],
-        params: Sequence[str],
-        tag_priority: Mapping[str | int, int],
-    ) -> tuple[Sequence[Any], ...]:
+    def _select_dps(
+        dps: Iterable[DataPoint], tag_priority: Mapping[str | int, int]
+    ) -> Iterable[DataPoint]:
         # select one datapoint per visit with highest tag priority
         selected_dps: dict[int, DataPoint] = {}
         for el in dps:
@@ -121,14 +119,23 @@ class LSSTT2Tabulator(AbsT2Tabulator):
                 )
             ):
                 selected_dps[key] = el
+        return selected_dps.values()
 
+    @staticmethod
+    def get_values(
+        dps: Iterable[DataPoint],
+        params: Sequence[str],
+        tag_priority: Mapping[str | int, int],
+    ) -> tuple[Sequence[Any], ...]:
         if tup := tuple(
             map(
                 list,
                 zip(
                     *(
                         [el["body"][param] for param in params]
-                        for el in selected_dps.values()
+                        for el in LSSTT2Tabulator._select_dps(
+                            dps, tag_priority
+                        )
                     ),
                     strict=False,
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ampel-lsst"
-version = "0.10.1a1"
+version = "0.10.1a2"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 authors = [
     "Marcus Fenner <mf@physik.hu-berlinn.de>",

--- a/tests/test-data/elasticc-consumer.yml
+++ b/tests/test-data/elasticc-consumer.yml
@@ -31,7 +31,6 @@ config:
               ingest:
                 filter: LSSTObjFilter
                 select: last
-                sort: diaObjectId
         combine:
           - unit: LSSTT1Combiner
   - channel: ElasticcShort

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -116,7 +116,9 @@ def test_duplicate_datapoints(mock_context: DevAmpelContext):
         model=UnitModel(**model.config["supplier"]), sub_type=LSSTAlertSupplier
     )
     alert = next(supplier)
-    assert len(alert.datapoints) == 20
+    assert len(alert.datapoints) == 17, (
+        "alert suppliert removed 3 duplicated datapoints"
+    )
 
     processor = mock_context.loader.new_context_unit(
         model=model,
@@ -125,13 +127,9 @@ def test_duplicate_datapoints(mock_context: DevAmpelContext):
         raise_exc=True,
     )
 
-    # insert datapoints from first alert into the database
     assert processor.run() == 1
 
     assert (t1 := mock_context.db.get_collection("t1").find_one())
     assert len(t1["dps"]) == len(set(t1["dps"])), (
         "datapoints in state are unique"
-    )
-    assert len(t1["dps"]) < len(alert.datapoints) - 1, (
-        "some alert datapoints eliminated"
     )


### PR DESCRIPTION
Rubin alerts contain a great number of fields that are likely only useful for filtering, but will only ever be ignored in light curve analysis. Drop these by default when creating T0 docs. Also, avoid ingesting historical difference photometry for visits where forced photometry is available in the same alert.

For the last 100 alerts in OR5, this reduces the size of T0 docs by a factor 3.8 (2.4 with zstd compression)