### PR TITLE
fix: Use diaSourceId for LSST cutout retrieval instead of DataPoint id

### DIFF
--- a/ampel/lsst/t3/complement/LSSTCutoutImages.py
+++ b/ampel/lsst/t3/complement/LSSTCutoutImages.py
@@ -75,7 +75,9 @@ class LSSTCutoutImages(AbsBufferComplement):
             elif self.eligible == "first":
                 candids = [_diasource_id(pps[0])]
             elif self.eligible == "brightest":
-                candids = [_diasource_id(max(pps, key=lambda pp: pp["body"]["psfFlux"]))]
+                candids = [
+                    _diasource_id(max(pps, key=lambda pp: pp["body"]["psfFlux"]))
+                ]
             else:  # all
                 candids = [_diasource_id(pp) for pp in pps]
 

--- a/ampel/lsst/t3/complement/LSSTCutoutImages.py
+++ b/ampel/lsst/t3/complement/LSSTCutoutImages.py
@@ -61,14 +61,24 @@ class LSSTCutoutImages(AbsBufferComplement):
             if not pps:
                 return
 
+            def _diasource_id(pp) -> int:
+                body = pp.get("body", {})
+                dsid = body.get("diaSourceId")
+                if dsid is None:
+                    raise KeyError(
+                        f"No diaSourceId in photopoint body keys={list(body.keys())}"
+                    )
+                return int(dsid)
+
             if self.eligible == "last":
-                candids = [pps[-1]["id"]]
+                candids = [_diasource_id(pps[-1])]
             elif self.eligible == "first":
-                candids = [pps[0]["id"]]
+                candids = [_diasource_id(pps[0])]
             elif self.eligible == "brightest":
-                candids = [max(pps, key=lambda pp: pp["body"]["psfFlux"])["id"]]
+                candids = [_diasource_id(max(pps, key=lambda pp: pp["body"]["psfFlux"]))]
             else:  # all
-                candids = [pp["id"] for pp in pps]
+                candids = [_diasource_id(pp) for pp in pps]
+
             cutouts = {candid: self.get_cutout(candid) for candid in candids}
 
             if "extra" not in record or record["extra"] is None:


### PR DESCRIPTION
This PR fixes LSST cutout retrieval by using the LSST diaSourceId from the datapoint body when calling the archive cutout endpoint. Previously, it used the datapoint ID pp["id"], which did not find any CutoutImages, as it does not match body["diaSourceId"]. 
