### PR TITLE
Inject missing depedencies in MultiChannelAlertConsumerTemplate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-lsst"
-version = "0.10.1a12"
+version = "0.10.1a13"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 requires-python = ">=3.11, <4"
 authors = [


### PR DESCRIPTION
During template resolution, inject dependencies of tied T2 units if they are not already configured. This is particularly useful for point dependencies of state units, for which ingest/link_override need to be configured to the same value.