### PR TITLE
fix: acknowledge SSObject alerts

### DIFF
--- a/ampel/lsst/alert/LSSTAlertSupplier.py
+++ b/ampel/lsst/alert/LSSTAlertSupplier.py
@@ -48,6 +48,10 @@ class LSSTAlertSupplier(BaseAlertSupplier):
 
     alert_identifier: Literal["diaSourceId", "alertId"] = "diaSourceId"
 
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._emitted_any = False
+
     @staticmethod
     def _shape_dp(d: dict) -> ReadOnlyDict:
         return ReadOnlyDict({_field_upgrades.get(k, k): v for k, v in d.items()})
@@ -124,7 +128,17 @@ class LSSTAlertSupplier(BaseAlertSupplier):
             d = self._deserialize(next(self.alert_loader))
 
             try:
-                return self._shape(d, self.max_history, self.alert_identifier)
+                alert = self._shape(d, self.max_history, self.alert_identifier)
+                self._emitted_any = True
+                return alert
             except DIAObjectMissingError:
                 # silently skip over SSObjects
+                if not self._emitted_any:
+                    # if we have not yet emitted any alerts, we can be sure that
+                    # all previous messages were handled, and acknowledge
+                    # immediately. this avoids an edge case where the source
+                    # partition only contains SSObject messages that will never
+                    # be acknowledged, and so consumed over and over until a
+                    # different message arrives
+                    self.alert_loader.acknowledge(iter([d]))  # type: ignore[list-item]
                 continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-lsst"
-version = "0.10.1a14"
+version = "0.10.1a15"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 requires-python = ">=3.11, <4"
 authors = [


### PR DESCRIPTION
KafkaAlertLoader relies on an acknowledgement callback to advance its stored offsets. Since LSSTAlertSupplier silently drops SSObject alerts, however, the offset can only advance after a non-SSObject alert is handled. This leads to an edge case where a run of SSObject alerts appear on a partition at the end of a night and are not marked as consumed until the next DIAObject alert arrives the next night.

Work around by immediately acknowledging dropped alerts as long as no alerts have been delivered to the alert consumer.