### PR TITLE
Add id and id source columns to LSSTT2Tabulator

### DIFF
--- a/ampel/lsst/view/LSSTT2Tabulator.py
+++ b/ampel/lsst/view/LSSTT2Tabulator.py
@@ -44,10 +44,19 @@ class LSSTT2Tabulator(AbsT2Tabulator):
         self,
         dps: Iterable[DataPoint],
     ) -> Table:
-        flux, fluxerr, filtername, tai = self.get_values(
-            dps,
-            ["psfFlux", "psfFluxErr", "band", "midpointMjdTai"],
-            self._tag_priority,
+        diaSourceId, diaForcedSourceId, flux, fluxerr, filtername, tai = (
+            self.get_values(
+                dps,
+                [
+                    "diaSourceId",
+                    "diaForcedSourceId",
+                    "psfFlux",
+                    "psfFluxErr",
+                    "band",
+                    "midpointMjdTai",
+                ],
+                self._tag_priority,
+            )
         )
         if self.convert2jd:
             tai = self._to_jd(tai)
@@ -55,6 +64,13 @@ class LSSTT2Tabulator(AbsT2Tabulator):
 
         table = Table(
             {
+                "id": [
+                    d if d is not None else f
+                    for d, f in zip(diaSourceId, diaForcedSourceId, strict=True)
+                ],
+                "source": [
+                    "LSST_DP" if d is not None else "LSST_FP" for d in diaSourceId
+                ],
                 "time": tai,
                 "flux": flux,
                 "fluxerr": fluxerr,
@@ -62,7 +78,16 @@ class LSSTT2Tabulator(AbsT2Tabulator):
                 "zp": [self.zp] * len(filters),
                 "zpsys": ["ab"] * len(filters),
             },
-            dtype=("float64", "float64", "float64", "str", "float64", "str"),
+            dtype=(
+                "int64",
+                "str",
+                "float64",
+                "float64",
+                "float64",
+                "str",
+                "float64",
+                "str",
+            ),
         )
 
         if self.allow_nan_flux:
@@ -122,13 +147,14 @@ class LSSTT2Tabulator(AbsT2Tabulator):
         dps: Iterable[DataPoint],
         params: Sequence[str],
         tag_priority: Mapping[str | int, int],
+        sentinel: Any = None,
     ) -> tuple[Sequence[Any], ...]:
         if tup := tuple(
             map(
                 list,
                 zip(
                     *(
-                        [el["body"][param] for param in params]
+                        [el["body"].get(param, sentinel) for param in params]
                         for el in LSSTT2Tabulator._select_dps(dps, tag_priority)
                     ),
                     strict=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ampel-lsst"
-version = "0.10.1a15"
+version = "0.10.1a16"
 description = "Legacy Survey of Space and Time support for the Ampel system"
 requires-python = ">=3.11, <4"
 authors = [

--- a/tests/test_tabulator.py
+++ b/tests/test_tabulator.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from pathlib import Path
 
 import bson
@@ -28,3 +29,10 @@ def test_tabulator(datapoints):
     assert len(tab) < len(datapoints)
     assert len(np.unique(tab["time"])) == len(tab["time"])
     assert tab["flux"][np.argsort(tab["time"])].tolist() == dp_if_not_fp
+
+    # source column is assigned
+    source_counts = Counter(tab["source"])
+    assert source_counts["LSST_FP"] == 4
+    assert source_counts["LSST_DP"] == len(tab) - 4
+    # id column is assigned and unique
+    assert len(np.unique(tab["id"])) == len(tab)


### PR DESCRIPTION
This allows downstream consumers to identify exactly which photometric points are were used, and whether they were forced or difference mode.